### PR TITLE
feat: MailerLite email capture integration + remove share buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,5 +6,6 @@ NEXT_PUBLIC_APP_DESCRIPTION="Assess your organization's experimentation maturity
 # Analytics (optional)
 NEXT_PUBLIC_GA_TRACKING_ID=
 
-# API Keys (if needed)
-# Add any API keys needed for your application 
+# API Keys
+# MailerLite API key for email subscriber integration (server-side only — no NEXT_PUBLIC_ prefix)
+MAILERLITE_API_KEY=your_mailerlite_api_key_here

--- a/src/pages/ResultsPage.fixed.tsx
+++ b/src/pages/ResultsPage.fixed.tsx
@@ -2,7 +2,7 @@ import React, { useEffect } from 'react';
 import { useQuiz } from '../context/QuizContext';
 import { Card, CardContent, CardHeader, CardTitle } from '../components/ui/Card';
 import { Button } from '../components/ui/Button';
-import { IconBrandX, IconBrandLinkedin, IconCalendar, IconFlask, IconRocket, IconBrain, IconTrophy } from '@tabler/icons-react';
+import { IconCalendar, IconFlask, IconRocket, IconBrain, IconTrophy } from '@tabler/icons-react';
 import { ThemeToggle } from '../components/ui/ThemeToggle';
 import { RadarChart } from '../components/ui/RadarChart';
 import { ScoreCard } from '../components/ui/ScoreCard';
@@ -170,18 +170,6 @@ export default function ResultsPage() {
     return CATEGORY_DESCRIPTIONS[category][level];
   };
 
-  const handleShare = (platform: 'twitter' | 'linkedin') => {
-    const url = window.location.href;
-    const text = `Check out my Experimentation Maturity Assessment results! My score: ${percentageScore}%`;
-    
-    const shareUrls = {
-      twitter: `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
-      linkedin: `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`
-    };
-
-    window.open(shareUrls[platform], '_blank');
-  };
-
   return (
     <div className="min-h-screen p-8">
       <ThemeToggle className="absolute top-4 right-4" />
@@ -314,22 +302,6 @@ export default function ResultsPage() {
                 </p>
 
                 <div className="flex flex-wrap gap-6 justify-center">
-                  <Button
-                    variant="outline"
-                    onClick={() => handleShare('twitter')}
-                    className="min-w-[200px] transition-all duration-300 hover:-translate-y-1 hover:shadow-lg bg-black text-white hover:bg-black/90 dark:bg-white dark:text-black dark:hover:bg-white/90"
-                  >
-                    <IconBrandX className="mr-2 h-4 w-4" />
-                    Share on X
-                  </Button>
-                  <Button
-                    variant="outline"
-                    onClick={() => handleShare('linkedin')}
-                    className="min-w-[200px] transition-all duration-300 hover:-translate-y-1 hover:shadow-lg"
-                  >
-                    <IconBrandLinkedin className="mr-2 h-4 w-4" />
-                    Share on LinkedIn
-                  </Button>
                   <Button
                     variant="default"
                     onClick={() => window.open('https://cal.com/kyznacademy/intro', '_blank')}

--- a/src/pages/api/subscribe.ts
+++ b/src/pages/api/subscribe.ts
@@ -1,0 +1,53 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+const MAILERLITE_GROUP_ID = '180387872171361369';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const { email, name, company, score, personaName } = req.body ?? {};
+
+  if (!email) {
+    return res.status(400).json({ error: 'Email is required' });
+  }
+
+  const apiKey = process.env.MAILERLITE_API_KEY;
+  if (!apiKey) {
+    console.error('MAILERLITE_API_KEY is not set');
+    return res.status(500).json({ error: 'API key not configured' });
+  }
+
+  try {
+    const response = await fetch('https://connect.mailerlite.com/api/subscribers', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        email,
+        fields: {
+          name: name || '',
+          company: company || '',
+          quiz_score: score != null ? String(score) : '',
+          persona: personaName || '',
+        },
+        groups: [MAILERLITE_GROUP_ID],
+      }),
+    });
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      console.error('MailerLite API error:', response.status, body);
+      return res.status(response.status).json({ error: (body as { message?: string }).message ?? 'Subscription failed' });
+    }
+
+    return res.status(200).json({ success: true });
+  } catch (err) {
+    console.error('MailerLite fetch error:', err);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+}

--- a/src/pages/email-capture.tsx
+++ b/src/pages/email-capture.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { motion } from 'framer-motion';
 import { useRouter } from 'next/router';
 import { useQuiz } from '../context/QuizContext';
+import { PERSONAS } from '../data/personas';
 import { generatePDFReport } from '../services/pdfService';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { Button } from '../components/ui/Button';
@@ -47,6 +48,24 @@ export default function EmailCapturePage() {
         email,
         userData,
       });
+
+      // Fire-and-forget: subscribe to MailerLite (only when email is provided)
+      if (email) {
+        const score = state.percentageScore ?? 0;
+        const level =
+          score < 20 ? 'novice'
+          : score < 40 ? 'beginner'
+          : score < 60 ? 'intermediate'
+          : score < 80 ? 'advanced'
+          : 'expert';
+        const personaName = PERSONAS[level].title;
+
+        fetch('/api/subscribe', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ email, name, company, score, personaName }),
+        }).catch(err => console.error('MailerLite subscription failed:', err));
+      }
 
       await generatePDFReport({
         ...state,


### PR DESCRIPTION
## Summary

- **New API route** `src/pages/api/subscribe.ts` — server-side Next.js handler that POSTs subscriber data to MailerLite (group `180387872171361369`) including `quiz_score` and `persona` as custom fields; uses `MAILERLITE_API_KEY` env var (never exposed to the client)
- **Email capture wired up** — `email-capture.tsx` now fires a fire-and-forget `fetch('/api/subscribe', ...)` after form submit when email is present; users who skip or leave email blank trigger no API call
- **Share buttons removed** — `IconBrandX`, `IconBrandLinkedin`, and `handleShare` stripped from `ResultsPage.fixed.tsx`; CTA section now shows only the "Book a Call" button
- **`.env.example` updated** with `MAILERLITE_API_KEY` placeholder and comment

## ⚠️ Action Required Before This Goes Live

Two custom fields need to be created in MailerLite before `quiz_score` and `persona` will persist on subscribers:

1. Log in to MailerLite → **Subscribers** → **Custom fields**
2. Add field key `quiz_score` (type: Text)
3. Add field key `persona` (type: Text)

Also add `MAILERLITE_API_KEY` to **Vercel → Settings → Environment Variables** (Production + Preview).

## Test plan

- [ ] Set `MAILERLITE_API_KEY` in `.env.local` and run `npm run dev`
- [ ] Complete the quiz, submit with a real email — verify subscriber appears in MailerLite group with name, company, score, and persona fields
- [ ] Complete quiz again, click **Skip** — confirm no new subscriber is created in MailerLite
- [ ] On results page, confirm Share on X and Share on LinkedIn buttons are gone; only **Book a Call** remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)