### PR TITLE
fix: remove 2-second navigation delay on email capture submit

### DIFF
--- a/src/context/QuizContext.tsx
+++ b/src/context/QuizContext.tsx
@@ -285,6 +285,19 @@ function quizReducer(state: QuizState, action: QuizAction): QuizState {
       };
     }
 
+    case 'SUBMIT_EMAIL': {
+      return {
+        ...state,
+        email: action.email,
+        userData: action.userData,
+      };
+    }
+
+    case 'SKIP_EMAIL': {
+      // No state change needed — explicit case avoids silent default fallthrough
+      return state;
+    }
+
     case 'SET_LOADING':
       return {
         ...state,

--- a/src/pages/email-capture.tsx
+++ b/src/pages/email-capture.tsx
@@ -6,11 +6,10 @@ import { PERSONAS } from '../data/personas';
 import { generatePDFReport } from '../services/pdfService';
 import { LoadingSpinner } from '../components/LoadingSpinner';
 import { Button } from '../components/ui/Button';
-import { Card, CardHeader, CardContent } from '../components/ui/Card';
+import { Card, CardContent } from '../components/ui/Card';
 import { Input } from '../components/ui/Input';
 import { Label } from '../components/ui/Label';
 import { Alert, AlertDescription } from '../components/ui/Alert';
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from '../components/ui/Dialog';
 import { cn } from '../lib/utils';
 import { ThemeToggle } from '../components/ui/ThemeToggle';
 
@@ -27,7 +26,6 @@ export default function EmailCapturePage() {
   const [name, setName] = useState('');
   const [company, setCompany] = useState('');
   const [isGeneratingPDF, setIsGeneratingPDF] = useState(false);
-  const [showSuccessDialog, setShowSuccessDialog] = useState(false);
   const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -73,14 +71,11 @@ export default function EmailCapturePage() {
         userData,
       });
 
-      setShowSuccessDialog(true);
-      
-      setTimeout(() => {
-        router.push('/results');
-      }, 2000);
-    } catch (error) {
-      console.error('Error generating PDF:', error);
-      setError('Failed to generate PDF report. Please try again.');
+      // Navigate immediately — no delay to avoid mobile state loss
+      router.push('/results');
+    } catch (err) {
+      console.error('Error generating report:', err);
+      setError('Failed to generate report. Please try again.');
     } finally {
       setIsGeneratingPDF(false);
     }
@@ -96,7 +91,7 @@ export default function EmailCapturePage() {
       <div className="absolute top-4 right-4">
         <ThemeToggle />
       </div>
-      
+
       <div className="container max-w-lg mx-auto px-4 py-16">
         <motion.div
           initial="initial"
@@ -122,9 +117,9 @@ export default function EmailCapturePage() {
 
           <Card className="bg-card/50 backdrop-blur-sm border-2">
             <CardContent className="pt-6">
-              <motion.form 
-                variants={fadeInUp} 
-                onSubmit={handleSubmit} 
+              <motion.form
+                variants={fadeInUp}
+                onSubmit={handleSubmit}
                 className="space-y-6"
               >
                 <div className="space-y-4">
@@ -185,7 +180,7 @@ export default function EmailCapturePage() {
                     {isGeneratingPDF ? (
                       <div className="flex items-center justify-center space-x-2">
                         <LoadingSpinner size="small" />
-                        <span>Generating Report...</span>
+                        <span>Loading results...</span>
                       </div>
                     ) : (
                       'Get My Report'
@@ -212,19 +207,6 @@ export default function EmailCapturePage() {
           </Card>
         </motion.div>
       </div>
-
-      <Dialog open={showSuccessDialog} onOpenChange={setShowSuccessDialog}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle className="text-2xl font-bold flex items-center gap-2">
-              <span className="text-2xl">🎉</span> Report Generated!
-            </DialogTitle>
-            <p className="text-muted-foreground pt-2">
-              Your report has been generated and downloaded. Taking you to your results...
-            </p>
-          </DialogHeader>
-        </DialogContent>
-      </Dialog>
     </div>
   );
-} 
+}


### PR DESCRIPTION
## Problem

On mobile, submitting the email capture form caused a flicker and redirect back to quiz question 1 instead of reaching the results page.

**Root cause:** `handleSubmit` used `setTimeout(() => router.push('/results'), 2000)` — a 2-second delay while showing a success dialog. On mobile browsers/iOS, this window is long enough for the OS to suspend the tab or for the page to lose JS state. When state resets, `percentageScore` becomes `undefined`, the results page guard fires, and the user lands at `/quiz` question 1.

**Why Skip worked fine:** `handleSkip` calls `router.push('/results')` immediately with no delay.

**Secondary issue:** `SUBMIT_EMAIL` and `SKIP_EMAIL` had no `case` in the reducer switch statement — both fell silently to `default`, meaning `email` and `userData` were never stored in quiz state.

## Changes

**`src/pages/email-capture.tsx`**
- Removed `showSuccessDialog` state and `setTimeout` pattern
- Navigate to `/results` immediately after `generatePDFReport` resolves (consistent with `handleSkip`)
- Removed `Dialog` / `DialogContent` / `DialogHeader` / `DialogTitle` imports and JSX

**`src/context/QuizContext.tsx`**
- Added `case 'SUBMIT_EMAIL'`: stores `email` and `userData` in state
- Added `case 'SKIP_EMAIL'`: explicit no-op (avoids silent fallthrough)

## Test plan
- [ ] Complete quiz on mobile → fill in email capture form → "Get My Report" → lands on results immediately, no flicker
- [ ] Complete quiz → click "Skip and see results" → still navigates immediately
- [ ] Verify MailerLite receives subscriber when email is submitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)